### PR TITLE
Fix conditional comments in Microsoft Office documents

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,17 +10,18 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
          cacheDirectory=".phpunit.cache"
          backupStaticProperties="false">
-  <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+  <coverage/>
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./test</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Html/Filter/MicrosoftOffice.php
+++ b/src/Html/Filter/MicrosoftOffice.php
@@ -2,13 +2,19 @@
 
 namespace SupportPal\DomUtils\Html\Filter;
 
+use SupportPal\DomUtils\Html\LibXml;
 use function str_replace;
 use function strpos;
 
-use const LIBXML_DOTTED_VERSION;
-
 class MicrosoftOffice extends Filter
 {
+    private readonly LibXml $libXml;
+
+    public function __construct(?LibXml $libXml = null)
+    {
+        $this->libXml = $libXml === null ? new LibXml : $libXml;
+    }
+
     public function preProcess(string $text): string
     {
         if (! $this->isOfficeDocument($text)) {
@@ -34,7 +40,7 @@ class MicrosoftOffice extends Filter
 
     private function fixConditionalComments(string $html): string
     {
-        if (LIBXML_DOTTED_VERSION === '2.9.14') {
+        if ($this->libXml->getDottedVersion() === '2.9.14') {
             $html = preg_replace('/<!(\[if\s*[^\[\]]+\])>/', '<!--$1-->', $html);
             $html = preg_replace('/<!(\[endif\])>/', '<!--$1-->', $html);
         }

--- a/src/Html/Filter/MicrosoftOffice.php
+++ b/src/Html/Filter/MicrosoftOffice.php
@@ -3,6 +3,8 @@
 namespace SupportPal\DomUtils\Html\Filter;
 
 use SupportPal\DomUtils\Html\LibXml;
+
+use function preg_replace;
 use function str_replace;
 use function strpos;
 
@@ -41,8 +43,8 @@ class MicrosoftOffice extends Filter
     private function fixConditionalComments(string $html): string
     {
         if ($this->libXml->getDottedVersion() === '2.9.14') {
-            $html = preg_replace('/<!(\[if\s*[^\[\]]+\])>/', '<!--$1-->', $html);
-            $html = preg_replace('/<!(\[endif\])>/', '<!--$1-->', $html);
+            $html = preg_replace('/<!(\[if\s*[^\[\]]+\])>/', '<!--$1-->', $html) ?? $html;
+            $html = preg_replace('/<!(\[endif\])>/', '<!--$1-->', $html) ?? $html;
         }
 
         return $html;

--- a/src/Html/Filter/MicrosoftOffice.php
+++ b/src/Html/Filter/MicrosoftOffice.php
@@ -5,6 +5,8 @@ namespace SupportPal\DomUtils\Html\Filter;
 use function str_replace;
 use function strpos;
 
+use const LIBXML_DOTTED_VERSION;
+
 class MicrosoftOffice extends Filter
 {
     public function preProcess(string $text): string
@@ -13,7 +15,9 @@ class MicrosoftOffice extends Filter
             return $text;
         }
 
-        return $this->removeNamespacedParagraphs($text);
+        $text = $this->removeNamespacedParagraphs($text);
+
+        return $this->fixConditionalComments($text);
     }
 
     private function isOfficeDocument(string $html): bool
@@ -26,5 +30,15 @@ class MicrosoftOffice extends Filter
     private function removeNamespacedParagraphs(string $html): string
     {
         return str_replace(['<o:p>', '</o:p>'], '', $html);
+    }
+
+    private function fixConditionalComments(string $html): string
+    {
+        if (LIBXML_DOTTED_VERSION === '2.9.14') {
+            $html = preg_replace('/<!(\[if\s*[^\[\]]+\])>/', '<!--$1-->', $html);
+            $html = preg_replace('/<!(\[endif\])>/', '<!--$1-->', $html);
+        }
+
+        return $html;
     }
 }

--- a/src/Html/LibXml.php
+++ b/src/Html/LibXml.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace SupportPal\DomUtils\Html;
+
+use const LIBXML_DOTTED_VERSION;
+
+class LibXml
+{
+    public function getDottedVersion(): string
+    {
+        return LIBXML_DOTTED_VERSION;
+    }
+}

--- a/test/Html/Filter/MicrosoftOfficeTest.php
+++ b/test/Html/Filter/MicrosoftOfficeTest.php
@@ -45,5 +45,27 @@ class MicrosoftOfficeTest extends TestCase
 <body>Foo</body>
 </html>'
         ];
+
+        yield [
+            '<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>
+<![if !supportAnnotations]><style id="dynCom" type="text/css"><!-- --></style><![endif]>
+</head>
+</html>',
+            '<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>
+<!--[if !supportAnnotations]--><style id="dynCom" type="text/css"><!-- --></style><!--[endif]-->
+</head>
+</html>',
+        ];
+
+        yield [
+            '<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>
+<![if mso 9]><style id="dynCom" type="text/css"><!-- --></style><![endif]>
+</head>
+</html>',
+            '<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>
+<!--[if mso 9]--><style id="dynCom" type="text/css"><!-- --></style><!--[endif]-->
+</head>
+</html>',
+        ];
     }
 }

--- a/test/Html/Filter/MicrosoftOfficeTest.php
+++ b/test/Html/Filter/MicrosoftOfficeTest.php
@@ -5,6 +5,7 @@ namespace Test\Html\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SupportPal\DomUtils\Html\Filter\MicrosoftOffice;
 use SupportPal\DomUtils\Html\Html;
+use SupportPal\DomUtils\Html\LibXml;
 use Test\TestCase;
 
 class MicrosoftOfficeTest extends TestCase
@@ -45,7 +46,23 @@ class MicrosoftOfficeTest extends TestCase
 <body>Foo</body>
 </html>'
         ];
+    }
 
+    #[DataProvider('mockedProvider')]
+    public function testHtmlMockedLibXmlVersion(string $string, string $expected): void
+    {
+        $mock = $this->createMock(LibXml::class);
+        $mock->expects($this->once())->method('getDottedVersion')->willReturn('2.9.14');
+
+        $filter = new MicrosoftOffice($mock);
+        $this->assertSame($expected, $filter->preProcess($string));
+    }
+
+    /**
+     * @return iterable<string[]>
+     */
+    public static function mockedProvider(): iterable
+    {
         yield [
             '<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40"><head>
 <![if !supportAnnotations]><style id="dynCom" type="text/css"><!-- --></style><![endif]>


### PR DESCRIPTION
I think it's called downlevel-revealed conditional comments based on https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/ms537512(v=vs.85)?redirectedfrom=MSDN. The issue happens on libxml 2.9.14 as it reads it as an invalid <head> element, and moves it to <body>. It works OK in libxml 2.9.13